### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,13 +3,13 @@ One Click Demo Install for Wordpress Developers
 
 This library works by importing wordpress content, widgets  and theme options with just one click.
 
-##Supported Wordpress Options Frameworks
+## Supported Wordpress Options Frameworks
 * Radium Framework
 * Option Tree
 * Redux Framework - extension available here https://github.com/Webcreations907/WBC-Importer-extension 
 
 
-##Requirements:
+## Requirements:
 
 * WordPress Theme
 * Content.xml - generated using the Worpress Content Exporter plugin
@@ -17,7 +17,7 @@ This library works by importing wordpress content, widgets  and theme options wi
 * theme_options.txt - generated using the theme options frameworks such as Redux Framework, NHP Options Framework or Radium Framework
 * Change the $theme_options_framework variable found in the init file to match your framework.
 
-##How to use:
+## How to use:
 
 Add  `require get_template_directory() .'/radium-one-click-demo-install/init.php';` to your theme's function.php
 
@@ -34,7 +34,7 @@ Click the import button
 
 That's it.
 
-###Follow me on: 
+### Follow me on: 
 
 * Twitter: [twitter](http://twitter.com/Frankgm1 "@Frankgm1")
 * Website: [radiumthemes](http://radiumthemes.com/ "Radium Themes") 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
